### PR TITLE
Don't fail when pip does not find palettesnap

### DIFF
--- a/palettesnap/outdatedCheck.py
+++ b/palettesnap/outdatedCheck.py
@@ -12,9 +12,13 @@ from .console import console
 ###
 # Main functions
 ###
-def findCurrVersion() -> str:
+def findCurrVersion() -> str | None:
     '''returns user-installed version'''
-    res = subprocess.run(['pip', 'show', 'palettesnap'], capture_output=True).stdout.decode("utf-8")
+    proc = subprocess.run(['pip', 'show', 'palettesnap'], capture_output=True)
+    if proc.returncode != 0:
+        # pip failed to find palettesnap
+        return None
+    res = proc.stdout.decode("utf-8")
     version = res.splitlines()[1]
     version = version.split(" ")[1]
     return version
@@ -34,7 +38,7 @@ def outdatedCheck() -> None:
     '''check if user-installed version is outdated or not'''
     current = findCurrVersion()
     latest = findLatestVersion()
-    if latest == None:
+    if latest is None or current is None:
         console.log("Failed to check for palettesnap updates.")
     elif current != latest:
         console.log("Your version of palettesnap is [red]outdated[/red].")


### PR DESCRIPTION
On some linux distributions (cough cough fedora) `pip` command is still the one that uses `python 2.7`. As a result it can't find `pallettesnap` package and fails with the following error:

```
~ [1]$ palsnap gen --mode dark ~/Pictures/wallpapers/EAW-artilery.png
/home/hakiergrzonzo/.local/lib/python3.12/site-packages/colour/utilities/verbose.py:265: ColourWarning: "vaab/colour" was detected in "sys.path", please define a "COLOUR_SCIENCE__COLOUR__IMPORT_VAAB_COLOUR=True" environment variable to import its objects into "colour" namespace!
  warn(*args, **kwargs)  # noqa: B028
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/hakiergrzonzo/.local/lib/python3.12/site-packages/palettesnap/cli.py:137 in gen            │
│                                                                                                  │
│   134 │   '''                                                                                    │
│   135 │   Generates color palette given path to image and optional arguments.                    │
│   136 │   '''                                                                                    │
│ ❱ 137 │   outdatedCheck()                                                                        │
│   138 │   # precheck                                                                             │
│   139 │   if mode not in ["auto", "light", "dark"]:                                              │
│   140 │   │   raise typer.BadParameter(f"{mode} is not a valid mode. Allowed values are auto,    │
│                                                                                                  │
│ ╭─────────────────────────────────── locals ───────────────────────────────────╮                 │
│ │           cache = None                                                       │                 │
│ │    chromaFactor = 0.25                                                       │                 │
│ │ chromaThreshold = 3.0                                                        │                 │
│ │        dominant = 5                                                          │                 │
│ │           extra = False                                                      │                 │
│ │       hueFactor = 1.0                                                        │                 │
│ │    hueThreshold = 10.0                                                       │                 │
│ │             mix = False                                                      │                 │
│ │       mixAmount = 0.1                                                        │                 │
│ │    mixThreshold = 0.16                                                       │                 │
│ │            mode = 'dark'                                                     │                 │
│ │            path = '/home/hakiergrzonzo/Pictures/wallpapers/EAW-artilery.png' │                 │
│ │          sample = 10000                                                      │                 │
│ │            skip = False                                                      │                 │
│ │           tweak = False                                                      │                 │
│ │          weight = 100                                                        │                 │
│ ╰──────────────────────────────────────────────────────────────────────────────╯                 │
│                                                                                                  │
│ /home/hakiergrzonzo/.local/lib/python3.12/site-packages/palettesnap/outdatedCheck.py:35 in       │
│ outdatedCheck                                                                                    │
│                                                                                                  │
│   32                                                                                             │
│   33 def outdatedCheck() -> None:                                                                │
│   34 │   '''check if user-installed version is outdated or not'''                                │
│ ❱ 35 │   current = findCurrVersion()                                                             │
│   36 │   latest = findLatestVersion()                                                            │
│   37 │   if latest == None:                                                                      │
│   38 │   │   console.log("Failed to check for palettesnap updates.")                             │
│                                                                                                  │
│ /home/hakiergrzonzo/.local/lib/python3.12/site-packages/palettesnap/outdatedCheck.py:18 in       │
│ findCurrVersion                                                                                  │
│                                                                                                  │
│   15 def findCurrVersion() -> str:                                                               │
│   16 │   '''returns user-installed version'''                                                    │
│   17 │   res = subprocess.run(['pip', 'show', 'palettesnap'], capture_output=True).stdout.dec    │
│ ❱ 18 │   version = res.splitlines()[1]                                                           │
│   19 │   version = version.split(" ")[1]                                                         │
│   20 │   return version                                                                          │
│   21                                                                                             │
│                                                                                                  │
│ ╭─ locals ─╮                                                                                     │
│ │ res = '' │                                                                                     │
│ ╰──────────╯                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
IndexError: list index out of range
```

I made the current version check fail softly when that happens